### PR TITLE
Add support for authentication via AppRole

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,4 +153,6 @@ Note that environment variables can be overwritten by flags.
 * `VAULT_SKIP_VERIFY` – SkipVerify enables or disables SSL verification (defaults to `false`)
 * `VAULT_TLS_SERVER_NAME` – TLSServerName, if set, is used to set the SNI host when connecting via TLS (defaults to empty)
 * `VAULT_MAX_RETRIES` – MaxRetries controls the maximum number of times to retry when a 5xx error occurs (defaults to `0`)
-* `VAULT_TOKEN` – Token is the access token used by client
+* `VAULT_ROLE_ID` – Role ID for authenticating via AppRole
+* `VAULT_SECRET_ID` – Secret ID for authenticating via AppRole
+* `VAULT_APPROLE_MOUNTPOINT` – Mountpoint of the AppRole backend

--- a/README.md
+++ b/README.md
@@ -52,6 +52,9 @@ Flags:
                                  Address to listen on for web interface and telemetry. Env var: WEB_LISTEN_ADDRESS
       --web.telemetry-path="/metrics"  
                                  Path under which to expose metrics. Env var: WEB_TELEMETRY_PATH
+      --web.basic-auth=WEB.BASIC-AUTH
+                                 Basic auth credentials in htpasswd format, e.g. 'test:$2y$05$FIYPVfTq2ZSRyFKm1z'. Create with `htpasswd -B
+                                 -n my_user`. Env var WEB_BASIC_AUTH
       --vault-tls-cacert=VAULT-TLS-CACERT  
                                  The path to a PEM-encoded CA cert file to use to verify the Vault server SSL certificate.
       --vault-tls-client-cert=VAULT-TLS-CLIENT-CERT  

--- a/README.md
+++ b/README.md
@@ -49,20 +49,67 @@ usage: vault_exporter [<flags>]
 Flags:
   -h, --help              Show context-sensitive help (also try --help-long and --help-man).
       --web.listen-address=":9410"  
-                          Address to listen on for web interface and telemetry.
+                                 Address to listen on for web interface and telemetry. Env var: WEB_LISTEN_ADDRESS
       --web.telemetry-path="/metrics"  
-                          Path under which to expose metrics.
+                                 Path under which to expose metrics. Env var: WEB_TELEMETRY_PATH
       --vault-tls-cacert=VAULT-TLS-CACERT  
-                          The path to a PEM-encoded CA cert file to use to verify the Vault server SSL certificate.
+                                 The path to a PEM-encoded CA cert file to use to verify the Vault server SSL certificate.
       --vault-tls-client-cert=VAULT-TLS-CLIENT-CERT  
-                          The path to the certificate for Vault communication.
+                                 The path to the certificate for Vault communication.
       --vault-tls-client-key=VAULT-TLS-CLIENT-KEY  
-                          The path to the private key for Vault communication.
-      --insecure-ssl      Set SSL to ignore certificate validation.
+                                 The path to the private key for Vault communication.
+      --insecure-ssl             Set SSL to ignore certificate validation.
+      --tls.enable="false"       Enable TLS (true/false). Env var: TLS_ENABLE
+      --tls.prefer-server-cipher-suites="true"
+                                 Server selects the client's most preferred cipher suite (true/false). Env var:
+                                 TLS_PREFER_SERVER_CIPHER_SUITES
+      --tls.key-file=TLS.KEY-FILE
+                                 Path to the private key file. Env var: TLS_KEY_FILE
+      --tls.cert-file=TLS.CERT-FILE
+                                 Path to the cert file. Can contain multiple certs. Env var: TLS_CERT_FILE
+      --tls.min-ver=TLS12        TLS minimum version. Env var: TLS_MIN_VER
+      --tls.max-ver=TLS13        TLS maximum version. Env var: TLS_MAX_VER
+      --tls.cipher-suite=TLS.CIPHER-SUITE ...
+                                 Allowed cipher suite (See https://golang.org/pkg/crypto/tls/#pkg-constants). Specify multiple times for
+                                 adding more suites. Default: built-in cipher list. Env var: TLS_CIPHER_SUITES - separate multiple values
+                                 with a new line
+      --tls.curve=TLS.CURVE ...  Allowed curves for an elliptic curve (See https://golang.org/pkg/crypto/tls/#CurveID). Default: built-in
+                                 curves list. Env var: TLS_CURVES - separate multiple values with a new line
       --log.level="info"  Only log messages with the given severity or above. Valid levels: [debug, info, warn, error, fatal]
       --log.format="logger:stderr"  
                           Set the log target and format. Example: "logger:syslog?appname=bob&local=7" or "logger:stdout?json=true"
       --version           Show application version.
+```
+
+## TLS Examples
+
+```bash
+./vault_exporter --tls.enable --tls.key-file=localhost.key --tls.cert-file=localhost.crt
+```
+
+Define list of ciphers
+```bash
+./vault_exporter --tls.enable=true --tls.key-file=localhost.key --tls.cert-file=localhost.crt \
+                 --tls.cipher-suite="TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384" \
+                 --tls.cipher-suite="TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"
+```
+
+Define list of ciphers via environment variables
+```bash
+# Note the newline
+TLS_CIPHER_SUITES="TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+"
+./vault_exporter --tls.enable=true --tls.key-file=localhost.key --tls.cert-file=localhost.crt
+```
+
+## Generate TLS cert for local development
+
+```bash
+openssl req -new -nodes -subj "/C=DE/CN=localhost" \
+                  -addext "subjectAltName = DNS:localhost" \
+                  -newkey rsa:2048 -keyout localhost.key -out localhost.csr
+openssl  x509  -req  -days 365  -in localhost.csr  -signkey localhost.key  -out localhost.crt
 ```
 
 ## Environment variables

--- a/README.md
+++ b/README.md
@@ -112,6 +112,23 @@ openssl req -new -nodes -subj "/C=DE/CN=localhost" \
 openssl  x509  -req  -days 365  -in localhost.csr  -signkey localhost.key  -out localhost.crt
 ```
 
+## Basic Auth
+
+vault_exporter expects the basic auth credentials in the _htpasswd_ format. They can be created with the `htpasswd` 
+command line utility (user: test, pass: test):
+```bash
+$ htpasswd -B -n test
+New password:
+Re-type new password:
+test:$2y$05$tlFqYpCCutsYxANpwSEVEOLAP1KXm.Ndp1Vt5cPqD2mN9xPyfxkq2
+```
+
+Then just passt the resulting string with the bcrypt encrypted password via command line:
+
+```bash
+./vault_exporter --web.basic-auth='test:$2y$05$tlFqYpCCutsYxANpwSEVEOLAP1KXm.Ndp1Vt5cPqD2mN9xPyfxkq2'
+``` 
+
 ## Environment variables
 
 Note that environment variables can be overwritten by flags.

--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ Flags:
                                  The path to the certificate for Vault communication.
       --vault-tls-client-key=VAULT-TLS-CLIENT-KEY  
                                  The path to the private key for Vault communication.
+      --vault-metrics            Adds Vault's metrics from sys/health to the Vault exporter's metrics output. Only the primary node delivers
+                                 these metrics. Env var: VAULT_METRICS
       --insecure-ssl             Set SSL to ignore certificate validation.
       --tls.enable="false"       Enable TLS (true/false). Env var: TLS_ENABLE
       --tls.prefer-server-cipher-suites="true"
@@ -83,6 +85,12 @@ Flags:
                           Set the log target and format. Example: "logger:syslog?appname=bob&local=7" or "logger:stdout?json=true"
       --version           Show application version.
 ```
+
+## Vault metrics
+
+A Vault primary node exposes under the endpoint `sys/metrics` some detailed metrics. For the sake of simplicity, 
+Vault exporter proxies these metrics and adds in case of a name clash the prefix _vault_ to the metric family  
+name. You can disable the Vault metrics by appending "--vault-metrics=false" to the command line.
 
 ## TLS Examples
 

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/giantswarm/vault-exporter
 go 1.14
 
 require (
+	github.com/abbot/go-http-auth v0.4.0
 	github.com/frankban/quicktest v1.4.1 // indirect
 	github.com/giantswarm/microerror v0.2.0
 	github.com/go-test/deep v1.0.2 // indirect

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/hashicorp/vault/sdk v0.1.14-0.20200429182704-29fce8f27ce4 // indirect
 	github.com/pierrec/lz4 v2.2.6+incompatible // indirect
 	github.com/prometheus/client_golang v1.4.0
+	github.com/prometheus/client_model v0.2.0
 	github.com/prometheus/common v0.9.1
 	golang.org/x/crypto v0.0.0-20200117160349-530e935923ad // indirect
 	golang.org/x/net v0.0.0-20200114155413-6afb5195e5aa // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,8 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
+github.com/abbot/go-http-auth v0.4.0 h1:QjmvZ5gSC7jm3Zg54DqWE/T5m1t2AfDu6QlXJT0EVT0=
+github.com/abbot/go-http-auth v0.4.0/go.mod h1:Cz6ARTIzApMJDzh5bRMSUou6UMSp0IEXg9km/ci7TJM=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 h1:JYp7IbQjafoB+tBA3gMyHYHrpOtNuDiK/uB5uXxq5wM=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=

--- a/main.go
+++ b/main.go
@@ -320,7 +320,7 @@ func listen(listenAddress string, tlsCliConfig *tlsCliConfig) error {
 }
 
 func basicAuthProvider() (*auth.BasicAuth, error) {
-	if basicAuthCreds == nil {
+	if *basicAuthCreds == "" {
 		return nil, nil
 	}
 


### PR DESCRIPTION
if the environment variables `VAULT_ROLE_ID` and `VAULT_SECRET_ID` are set, Vault Exporter authenticates its requests to Vault via the AppRole mechanism.

This PR depends on #29 and #30 .