### PR TITLE
Fix: Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
 DOCKER_IMAGE_NAME ?= grapeshot/vault_exporter
 
-vault_exporter: main.go
+vault-exporter:
 	go build -o $@ ./
 
-.uptodate: vault_exporter Dockerfile
+.uptodate: vault-exporter
 	docker build -t $(DOCKER_IMAGE_NAME):$(shell git rev-parse --short HEAD) .
 
 clean:


### PR DESCRIPTION
This fixes two issues:

1. Some target's dependencies aren't actually targets: `main.go`, `Dockerfile`
2. In a clean working tree, the target `.uptodate` doesn't actually work, because the target is named `vault_exporter`:
```
make .uptodate                                                                                                                                                                                                                                                                                                                                                    INSERT
go build -o vault_exporter ./
docker build -t grapeshot/vault_exporter:b278e1e .
[+] Building 3.8s (6/6) FINISHED                                                                                                                                                                                                                                                                                                                                           
 => [internal] load build definition from Dockerfile                                                                                                                                                                                                                                                                                                                  0.0s
 => => transferring dockerfile: 125B                                                                                                                                                                                                                                                                                                                                  0.0s
 => [internal] load .dockerignore                                                                                                                                                                                                                                                                                                                                     0.0s
 => => transferring context: 2B                                                                                                                                                                                                                                                                                                                                       0.0s
 => [internal] load metadata for docker.io/library/alpine:3.5                                                                                                                                                                                                                                                                                                         3.6s
 => [internal] load build context                                                                                                                                                                                                                                                                                                                                     0.0s
 => => transferring context: 2B                                                                                                                                                                                                                                                                                                                                       0.0s
 => [1/2] FROM docker.io/library/alpine:3.5@sha256:66952b313e51c3bd1987d7c4ddf5dba9bc0fb6e524eed2448fa660246b3e76ec                                                                                                                                                                                                                                                   0.1s
 => => resolve docker.io/library/alpine:3.5@sha256:66952b313e51c3bd1987d7c4ddf5dba9bc0fb6e524eed2448fa660246b3e76ec                                                                                                                                                                                                                                                   0.0s
 => => sha256:66952b313e51c3bd1987d7c4ddf5dba9bc0fb6e524eed2448fa660246b3e76ec 433B / 433B                                                                                                                                                                                                                                                                            0.0s
 => => sha256:f7d2b5725685826823bc6b154c0de02832e5e6daf7dc25a00ab00f1158fabfc8 528B / 528B                                                                                                                                                                                                                                                                            0.0s
 => => sha256:f80194ae2e0ccf0f098baa6b981396dfbffb16e6476164af72158577a7de2dd9 1.51kB / 1.51kB                                                                                                                                                                                                                                                                        0.0s
 => ERROR [2/2] ADD vault-exporter /usr/bin                                                                                                                                                                                                                                                                                                                           0.0s
------
 > [2/2] ADD vault-exporter /usr/bin:
------
failed to compute cache key: "/vault-exporter" not found: not found
gmake: *** [Makefile:7: .uptodate] Error 1
```
